### PR TITLE
Adding User Interface for Custom Keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,26 @@ let g:claude_api_key = 'your_api_key_here'
 
 (You can also use AWS Bedrock as your Claude provider instead - in that case, set `let g:claude_use_bedrock = 1` instead.)
 
+You can edit the keybindings as follows:
+
+```vim
+let g:claude_implement_keybinding = "<Leader>ci"
+let g:claude_open_chat_keybinding = "<Leader>cc"
+let g:claude_send_chat_message_keybinding = "<C-]>"
+let g:claude_cancel_response_keybinding = "<Leader>cx"
+```
+
 ## Usage
 
 First, a couple of vim concepts you should be roughly familiar with:
+
 - Switching between windows (`:help windows`) - at least `<C-W><C-W>` to cycle between active windows
 - Diff mode (`:help diff`) - at least `d` `o` to accept the change under cursor
 - Folds (`:help folding`) - at least `z` `o` to open a fold (chat interaction) and `z` `c` to close it
 - Leader (`:help leader`) - if you are unsure, most likely `\` is the key to press whenever `<Leader>` is mentioned (but on new keyboards, `§` or `±` might be a nice leader to set)
 
 Claude.vim currently offers two main interaction modes:
+
 1. Simple implementation assistant
 2. Chat interface
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ let g:claude_api_key = 'your_api_key_here'
 You can edit the keybindings as follows:
 
 ```vim
-let g:claude_implement_keybinding = "<Leader>ci"
-let g:claude_open_chat_keybinding = "<Leader>cc"
-let g:claude_send_chat_message_keybinding = "<C-]>"
-let g:claude_cancel_response_keybinding = "<Leader>cx"
+let g:claude_map_implement = "<Leader>ci"
+let g:claude_map_open_chat = "<Leader>cc"
+let g:claude_map_send_chat_message = "<C-]>"
+let g:claude_map_cancel_response = "<Leader>cx"
 ```
 
 ## Usage

--- a/plugin/claude.vim
+++ b/plugin/claude.vim
@@ -30,20 +30,20 @@ if !exists('g:claude_aws_profile')
   let g:claude_aws_profile = ''
 endif
 
-if !exists('g:claude_implement_keybinding')
-  let g:claude_implement_keybinding = '<leader>ci'
+if !exists('g:claude_map_implement')
+  let g:claude_map_implement = '<leader>ci'
 endif
 
-if !exists('g:claude_open_chat_keybinding')
-  let g:claude_open_chat_keybinding = '<leader>cc'
+if !exists('g:claude_map_open_chat')
+  let g:claude_map_open_chat = '<leader>cc'
 endif
 
-if !exists('g:claude_send_chat_message_keybinding')
-  let g:claude_send_chat_message_keybinding = '<C-]>'
+if !exists('g:claude_map_send_chat_message')
+  let g:claude_map_send_chat_message = '<C-]>'
 endif
 
-if !exists('g:claude_cancel_response_keybinding')
-  let g:claude_cancel_response_keybinding = '<leader>cx'
+if !exists('g:claude_map_cancel_response')
+  let g:claude_map_cancel_response = '<leader>cx'
 endif
 
 " ============================================================================
@@ -53,13 +53,13 @@ endif
 function! s:SetupClaudeKeybindings()
 
   command! -range -nargs=1 ClaudeImplement <line1>,<line2>call s:ClaudeImplement(<line1>, <line2>, <q-args>)
-  execute "vnoremap " . g:claude_implement_keybinding . " :ClaudeImplement<Space>"
+  execute "vnoremap " . g:claude_map_implement . " :ClaudeImplement<Space>"
 
   command! ClaudeChat call s:OpenClaudeChat()
-  execute "nnoremap " . g:claude_open_chat_keybinding . " :ClaudeChat<CR>"
+  execute "nnoremap " . g:claude_map_open_chat . " :ClaudeChat<CR>"
 
   command! ClaudeCancel call s:CancelClaudeResponse()
-  execute "nnoremap " . g:claude_cancel_response_keybinding . " :ClaudeCancel<CR>"
+  execute "nnoremap " . g:claude_map_cancel_response . " :ClaudeCancel<CR>"
 endfunction
 
 augroup ClaudeKeybindings
@@ -747,8 +747,8 @@ function! s:OpenClaudeChat()
 
     " Add mappings for this buffer
     command! -buffer -nargs=1 SendChatMessage call s:SendChatMessage(<q-args>)
-    execute "inoremap <buffer> " . g:claude_send_chat_message_keybinding . " <Esc>:call <SID>SendChatMessage('Claude:')<CR>"
-    execute "nnoremap <buffer> " . g:claude_send_chat_message_keybinding . " :call <SID>SendChatMessage('Claude:')<CR>"
+    execute "inoremap <buffer> " . g:claude_map_send_chat_message . " <Esc>:call <SID>SendChatMessage('Claude:')<CR>"
+    execute "nnoremap <buffer> " . g:claude_map_send_chat_message . " :call <SID>SendChatMessage('Claude:')<CR>"
   else
     let l:claude_winid = bufwinid(l:claude_bufnr)
     if l:claude_winid == -1


### PR DESCRIPTION
# Introduction
First of all, thank you for the great plugin!
This amazing utility has helped me a lot and I am excited to contribute and add value to it.

# Objective
The aim of this pull request is to introduce a user interface for custom keybindings.

# Implementation
- introduction of the following new global variables:
    - `claude_implement_keybinding`;
    - `claude_open_chat_keybinding`;
    - `claude_send_chat_message_keybinding`;
    - `claude_cancel_response_keybinding`;
- creation of the `SetupClaudeKeybindings` function to setup all non-buffer-specific keybindings;
- addition of new VimEnter autocmd to set the keybindings, following vim plugin guidelines;
- `Readme.md` edit to let users know about this new configuration option;